### PR TITLE
Fix typo in component example

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,7 @@ with many atomic tree-shakable stores.
       return { currentUser }
     }
   }
-</script>eturn <header>{currentUser.name}</header>
-}
+</script>
 ```
 
 [Nano Stores]: https://github.com/nanostores/nanostores/


### PR DESCRIPTION
Removes a template duplicate at the end of a component example