### PR TITLE
Fix missing use-store declaration in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "exports": {
     ".": "./index.js",
     "./devtools": "./devtools/index.js",
+    "./use-store": "./use-store/index.js",
     "./package.json": "./package.json"
   },
   "engines": {


### PR DESCRIPTION
### Problem

There is a missing declaration in the package.json for the use-store method, [vite](https://vitejs.dev/) throws an error because of that.

![screenshot](https://user-images.githubusercontent.com/677051/144982794-5f69e60a-ba5e-47be-88fc-5314d5b931b4.png)

### Solution

Add the missing declaration 😉 

